### PR TITLE
powerhal: create cgroup/cpuset to restrict tasks to certain CPUs

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -50,6 +50,8 @@ endif
 
 LOCAL_MODULE_OWNER := intel
 
+LOCAL_INIT_RC := powerhal.rc
+
 include $(BUILD_SHARED_LIBRARY)
 
 include $(call first-makefiles-under,$(LOCAL_PATH))

--- a/powerhal.rc
+++ b/powerhal.rc
@@ -1,0 +1,9 @@
+on post-fs
+    mkdir /dev/cpuset/non_interactive
+    write /dev/cpuset/non_interactive/mems 0
+    write /dev/cpuset/non_interactive/cpus 0-3
+    chown system system /dev/cpuset/non_interactive
+    chown system system /dev/cpuset/non_interactive/cpus
+
+    setprop ro.powerhal.cpuset_config """"
+


### PR DESCRIPTION
This exposes the cgroup/cpuset for power HAL to restrict
tasks to cetrain CPU cores, for purpose of saving power.

Signed-off-by: Ting Li <ting.li@intel.com>